### PR TITLE
make get/set object to work with maps

### DIFF
--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -81,6 +81,11 @@
       <version>${test.randomize-testing}</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.6.5</version>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -8,6 +8,8 @@
 
 package org.postgresql.jdbc;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.Driver;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.CachedQuery;
@@ -21,7 +23,6 @@ import org.postgresql.largeobject.LargeObject;
 import org.postgresql.largeobject.LargeObjectManager;
 import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
-import org.postgresql.util.HStoreConverter;
 import org.postgresql.util.PGBinaryObject;
 import org.postgresql.util.PGTime;
 import org.postgresql.util.PGTimestamp;
@@ -69,6 +70,9 @@ import java.util.TimeZone;
 import java.util.UUID;
 
 class PgPreparedStatement extends PgStatement implements PreparedStatement {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   protected final CachedQuery preparedQuery; // Query fragments for prepared statement.
   protected final ParameterList preparedParameters; // Parameter values for prepared statement.
 
@@ -560,16 +564,14 @@ class PgPreparedStatement extends PgStatement implements PreparedStatement {
   }
 
   private void setMap(int parameterIndex, Map<?, ?> x) throws SQLException {
-    int oid = connection.getTypeInfo().getPGType("hstore");
-    if (oid == Oid.UNSPECIFIED) {
-      throw new PSQLException(GT.tr("No hstore extension installed."),
-          PSQLState.INVALID_PARAMETER_TYPE);
-    }
-    if (connection.binaryTransferSend(oid)) {
-      byte[] data = HStoreConverter.toBytes(x, connection.getEncoding());
-      bindBytes(parameterIndex, data, oid);
-    } else {
-      setString(parameterIndex, HStoreConverter.toString(x), oid);
+    PGobject pgObject = new PGobject();
+    pgObject.setType("json");
+    try {
+      pgObject.setValue(OBJECT_MAPPER.writeValueAsString(x));
+      setPGobject(parameterIndex, pgObject);
+    } catch (JsonProcessingException e) {
+      throw new PSQLException(GT.tr("Cannot convert map to PGobject: {0}", pgObject.getValue()),
+        PSQLState.INVALID_PARAMETER_VALUE);
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -8,6 +8,7 @@
 
 package org.postgresql.jdbc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.PGResultSetMetaData;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.BaseStatement;
@@ -79,6 +80,8 @@ import java.util.UUID;
 
 
 public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultSet {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   // needed for updateable result set support
   private boolean updateable = false;
@@ -220,6 +223,15 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
       default:
         String type = getPGType(columnIndex);
 
+        if (type.equals("json")) {
+          PGobject pgObject = getObject(columnIndex, PGobject.class);
+          try {
+            return OBJECT_MAPPER.readValue(pgObject.getValue(), HashMap.class);
+          } catch (IOException e) {
+            throw new PSQLException(GT.tr("Cannot convert PGobject to map: {0}", pgObject.getValue()),
+              PSQLState.INVALID_PARAMETER_VALUE);
+          }
+        }
         // if the backend doesn't know the type then coerce to String
         if (type.equals("unknown")) {
           return getString(columnIndex);

--- a/pgjdbc/src/test/java/org/postgresql/crate/TestObjectIntegrationTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/crate/TestObjectIntegrationTest.java
@@ -1,0 +1,43 @@
+package org.postgresql.crate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestObjectIntegrationTest extends BasePgJDBCIntegrationTest {
+
+  @Before
+  public void before() throws SQLException {
+    connection.createStatement().execute("create table if not exists test.test (obj object as (n int))");
+  }
+
+  @After
+  public void after() throws SQLException {
+    connection.createStatement().execute("drop table test.test");
+  }
+
+  @Test
+  public void testSetGetObject() throws SQLException {
+    Map<String, Integer> expected = new HashMap<>();
+    expected.put("n", 1);
+    PreparedStatement statement = connection.prepareStatement("insert into test.test (obj) values (?)");
+    statement.setObject(1, expected);
+    statement.execute();
+
+    connection.createStatement().execute("refresh table test.test");
+    ResultSet resultSet = connection.createStatement().executeQuery("select obj from test.test");
+    resultSet.next();
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) resultSet.getObject(1);
+    assertEquals(expected, map);
+  }
+}


### PR DESCRIPTION
get/set object are well tested in crate-jdbc, lets get rid of this integration test a bit later.