### PR TITLE
enable `loadBalanceHosts` by default

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -355,7 +355,7 @@ public enum PGProperty {
   TARGET_SERVER_TYPE("targetServerType", "any", "Specifies what kind of server to connect", false,
       "any", "master", "slave", "preferSlave"),
 
-  LOAD_BALANCE_HOSTS("loadBalanceHosts", "false",
+  LOAD_BALANCE_HOSTS("loadBalanceHosts", "true",
       "If disabled hosts are connected in the given order. If enabled hosts are chosen randomly from the set of suitable candidates"),
 
   HOST_RECHECK_SECONDS("hostRecheckSeconds", "10",

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -705,7 +705,7 @@ public abstract class BaseDataSource implements Referenceable {
    * @see PGProperty#LOAD_BALANCE_HOSTS
    */
   public boolean getLoadBalanceHosts() {
-    return PGProperty.LOAD_BALANCE_HOSTS.isPresent(properties);
+    return PGProperty.LOAD_BALANCE_HOSTS.getBoolean(properties);
   }
 
   /**

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/PoolingDataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/PoolingDataSourceTest.java
@@ -139,4 +139,8 @@ public class PoolingDataSourceTest extends BaseDataSourceTest {
     assertEquals(hc1, hc2);
   }
 
+  public void testLoadBalanceHostsIsEnabledByDefault() {
+      initializeDataSource();
+      assertTrue(bds.getLoadBalanceHosts());
+  }
 }


### PR DESCRIPTION
No valid reason exist so far to not enable this but instead could
result in multiple clients always connecting to the same node if disabled.