### PR TITLE
Add support for negative row counts.

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/CommandCompleteParser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CommandCompleteParser.java
@@ -55,8 +55,8 @@ public final class CommandCompleteParser {
     try {
       int lastSpace = status.lastIndexOf(' ');
       // Status ends with a digit => it is ROWS
-      if (Parser.isDigitAt(status, lastSpace + 1)) {
-        rows = Parser.parseLong(status, lastSpace + 1, status.length());
+      if (Parser.isDigitOrMinusAt(status, lastSpace + 1)) {
+        rows = Parser.parseSignedLong(status, lastSpace + 1, status.length());
 
         if (Parser.isDigitAt(status, lastSpace - 1)) {
           int penultimateSpace = status.lastIndexOf(' ', lastSpace - 1);

--- a/pgjdbc/src/main/java/org/postgresql/core/Parser.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/Parser.java
@@ -26,6 +26,7 @@ import java.util.List;
  */
 public class Parser {
   private static final int[] NO_BINDS = new int[0];
+  private static char MINUS_SIGN = '-';
 
   /**
    * Parses JDBC query into PostgreSQL's native format. Several queries might be given if separated
@@ -711,6 +712,40 @@ public class Parser {
       res = res * 10 + digitAt(s, beginIndex);
     }
     return res;
+  }
+
+  /**
+   * Faster version of {@link Long#parseLong(String)} when parsing a substring is required which supports signed longs.
+   *
+   * @param s string to parse
+   * @param beginIndex begin index
+   * @param endIndex end index
+   * @return long value
+   */
+  static long parseSignedLong(String s, int beginIndex, int endIndex) {
+    boolean isNegative = s.charAt(beginIndex) == MINUS_SIGN;
+    if (isNegative) {
+      beginIndex++;
+    }
+    long res = parseLong(s, beginIndex, endIndex);
+    if (isNegative) {
+      return res * -1;
+    }
+    return res;
+  }
+
+  /**
+   * Returns true if a given string {@code s} has digit or '-' character at position {@code pos}.
+   * @param s input string
+   * @param pos position (0-based)
+   * @return true if input string s has digit at position pos
+   */
+  static boolean isDigitOrMinusAt(String s, int pos) {
+    if (pos <= 0 || pos > s.length()) {
+      return false;
+    }
+    char c = s.charAt(pos);
+    return Character.isDigit(c) || c == MINUS_SIGN;
   }
 
   /**

--- a/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/v3/QueryExecutorImpl.java
@@ -2486,7 +2486,7 @@ public class QueryExecutorImpl extends QueryExecutorBase {
       // then we set the result count to reflect that we cannot provide the actual number
       // due to the JDBC field being an int rather than a long.
       countAsInt = Statement.SUCCESS_NO_INFO;
-    } else if (count > 0) {
+    } else if (count >= Integer.MIN_VALUE) {
       countAsInt = (int) count;
     }
     handler.handleCommandStatus(status, countAsInt, oid);

--- a/pgjdbc/src/test/java/org/postgresql/core/CommandCompleteParserTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/CommandCompleteParserTest.java
@@ -28,7 +28,7 @@ public class CommandCompleteParserTest {
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][]{
         {"SELECT 0", 0, 0},
-        {"SELECT -42", 0, 0},
+        {"SELECT -42", 0, -42},
         {"SELECT", 0, 0},
         {"", 0, 0},
         {"A", 0, 0},


### PR DESCRIPTION
CrateDB returns a negative row count in some cases, e.g. -2 if the affected rows are unknown.
Due to recent changes (pgjdbc@06fefb4) support for a negative row count was removed.