### PR TITLE
information_schema.columns.is_generated type changed on CrateDB >= 4.0.0 

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1306,7 +1306,11 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
         tuple[12] = rs.getBytes("column_default");
         tuple[15] = rs.getBytes("character_octet_length");
         tuple[17] = connection.encodeString(rs.getBoolean("is_nullable") ? "YES" : "NO");
-        tuple[23] = connection.encodeString(rs.getBoolean("is_generated") ? "YES" : "NO");
+        if (getCrateVersion().before("4.0.0")) {
+          tuple[23] = connection.encodeString(rs.getBoolean("is_generated") ? "YES" : "NO");
+        } else {
+          tuple[23] = rs.getBytes("is_generated");
+        }
       }
         tuples.add(tuple);
     }


### PR DESCRIPTION
The type of the `information_schema.columns.is_generated` column has been changed
from Boolean to String for SQL standard compatibility.