### PR TITLE
get schema instead of catalog and simplify get primary keys query

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -1636,17 +1636,14 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       }
       return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(fields, tuples);
     } else {
-      StringBuilder sql = new StringBuilder("SELECT NULL AS \"TABLE_CAT\",\n" +
-                                            "  tc.table_catalog AS \"TABLE_SCHEM\",\n" +
-                                            "  tc.table_name AS \"TABLE_NAME\",\n" +
-                                            "  kcu.column_name AS \"COLUMN_NAME\",\n" +
-                                            "  kcu.ordinal_position AS \"KEY_SEQ\",\n" +
-                                            "  tc.constraint_name AS \"PK_NAME\"\n" +
-                                            "FROM information_schema.table_constraints tc\n" +
-                                            "  INNER JOIN information_schema.key_column_usage kcu\n" +
-                                            "  ON tc.constraint_name = kcu.constraint_name\n" +
-                                            "  AND tc.table_catalog = kcu.table_catalog \n" +
-                                            "WHERE tc.table_name = '" + connection.escapeString(table) + "'\n");
+      StringBuilder sql = new StringBuilder("SELECT kcu.table_catalog AS \"TABLE_CAT\",\n" +
+              "  kcu.table_schema AS \"TABLE_SCHEM\",\n" +
+              "  kcu.table_name AS \"TABLE_NAME\",\n" +
+              "  kcu.column_name AS \"COLUMN_NAME\",\n" +
+              "  kcu.ordinal_position AS \"KEY_SEQ\",\n" +
+              "  kcu.constraint_name AS \"PK_NAME\"\n" +
+              " FROM information_schema.key_column_usage kcu\n" +
+              " WHERE kcu.table_name = '" + connection.escapeString(table) + "'\n");
       if (schema != null) {
         sql.append("  AND tc.table_schema = '" + connection.escapeString(schema) + "'\n");
       }


### PR DESCRIPTION
backport of the https://github.com/crate/pgjdbc/commit/3d3d284bf2ed4398a74e96aad3a11c57f81785cc
change itself is BWC, new query would return same result as old one, so just added it to the latest release branch. I will update crate-jdbc to point to this commit as a follow up

Closes https://github.com/crate/crate-alerts/issues/306