### PR TITLE
Update `jackson-databind` to 2.15.1

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -5,6 +5,7 @@ Changes in comparison to the upstream driver, forked at version REL42.2.5.
 ## [Unreleased]
 - Adjust `postgresql.util.StreamWrapper` for compatibility with newer versions of Java.
   `StreamWrapper.finalize()` needs to catch `Throwable` now.
+- Update `jackson-databind` to 2.15.1
 
 ## [x.x.x] (2022-07-28)
 - Get schema instead of catalog and simplify get primary keys query (#39)

--- a/pgjdbc/pom.xml
+++ b/pgjdbc/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.5</version>
+      <version>2.15.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
As suggested by @alija83 at https://github.com/crate/crate-jdbc/issues/386, this patch bumps the dependency version of `jackson-databind` to 2.15.1. Thank you.