### PR TITLE
Adjust `postgresql.util.StreamWrapper` for compatibility with newer Java versions

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -3,6 +3,8 @@
 Changes in comparison to the upstream driver, forked at version REL42.2.5.
 
 ## [Unreleased]
+- Adjust `postgresql.util.StreamWrapper` for compatibility with newer versions of Java.
+  `StreamWrapper.finalize()` needs to catch `Throwable` now.
 
 ## [x.x.x] (2022-07-28)
 - Get schema instead of catalog and simplify get primary keys query (#39)

--- a/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/org/postgresql/util/StreamWrapper.java
@@ -113,11 +113,23 @@ public class StreamWrapper {
             }
           }
 
+          @SuppressWarnings({"deprecation", "removal"})
           protected void finalize() throws IOException {
             // forcibly close it because super.finalize() may keep the FD open, which may prevent
             // file deletion
             close();
-            super.finalize();
+            // javac 13 assumes it can throw Throwable
+            try {
+              super.finalize();
+            } catch (RuntimeException e) {
+              throw e;
+            } catch (Error e) {
+              throw e;
+            } catch (IOException e) {
+              throw e;
+            } catch (Throwable e) {
+              throw new RuntimeException("Unexpected exception from finalize", e);
+            }
           }
         };
       } else {


### PR DESCRIPTION
As suggested by @BaurzhanSakhariev at https://github.com/crate/pgjdbc/pull/44#issuecomment-1558033039. Thanks!

The patch resolves this error.
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project postgresql: Compilation failure
[ERROR] /Users/amo/dev/crate/drivers/pgjdbc/pgjdbc/target/gen-src/org/postgresql/util/StreamWrapper.java:[120,27] unreported exception java.lang.Throwable; must be caught or declared to be thrown
```
