### PR TITLE
Chore: Satisfy checkstyle linter

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/CrateVersion.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/CrateVersion.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2016, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
 package org.postgresql.jdbc;
 
 public class CrateVersion implements Comparable<String> {
@@ -14,7 +19,7 @@ public class CrateVersion implements Comparable<String> {
     String[] v2 = o.split("\\.");
     int i = 0;
     while (i < v1.length && i < v2.length && v1[i].equals(v2[i])) {
-        i++;
+      i++;
     }
     if (i < v1.length && i < v2.length) {
       int diff = Integer.valueOf(v1[i]).compareTo(Integer.valueOf(v2[i]));

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.jdbc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.BaseStatement;
 import org.postgresql.core.Encoding;
@@ -17,6 +16,8 @@ import org.postgresql.util.ByteConverter;
 import org.postgresql.util.GT;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.Driver;
 import org.postgresql.PGNotification;
 import org.postgresql.PGProperty;
@@ -23,7 +21,6 @@ import org.postgresql.core.QueryExecutor;
 import org.postgresql.core.ReplicationProtocol;
 import org.postgresql.core.ResultHandlerBase;
 import org.postgresql.core.ServerVersion;
-import org.postgresql.core.SqlCommand;
 import org.postgresql.core.TransactionState;
 import org.postgresql.core.TypeInfo;
 import org.postgresql.core.Utils;
@@ -39,6 +36,9 @@ import org.postgresql.util.PGBinaryObject;
 import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.sql.Array;
@@ -751,8 +751,8 @@ public class PgConnection implements BaseConnection {
     if (this.autoCommit == autoCommit) {
       return;
     } else if (!autoCommit && strict) {
-      throw new SQLFeatureNotSupportedException("The auto-commit mode cannot be disabled in strict mode. "+
-              "The Crate JDBC driver does not support manual commit.");
+      throw new SQLFeatureNotSupportedException("The auto-commit mode cannot be disabled in strict mode. "
+              + "The Crate JDBC driver does not support manual commit.");
     }
     this.autoCommit = autoCommit;
   }
@@ -788,8 +788,8 @@ public class PgConnection implements BaseConnection {
     checkClosed();
 
     if (autoCommit && strict) {
-      throw new SQLFeatureNotSupportedException("The commit operation is not allowed. " +
-            "The Crate JDBC driver does not support manual commit.");
+      throw new SQLFeatureNotSupportedException("The commit operation is not allowed. "
+            + "The Crate JDBC driver does not support manual commit.");
     }
   }
 

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java
@@ -41,6 +41,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   private int INDEX_MAX_KEYS = 0; // maximum number of keys in an index.
 
   private static final Map<String, String> REFERENCE_GENERATIONS;
+
   static {
     Map<String, String> referenceMaps = new HashMap<>();
     referenceMaps.put("SYSTEM GENERATED", "SYSTEM");
@@ -257,46 +258,46 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   @Override
   public String getSQLKeywords() throws SQLException {
     connection.checkClosed();
-    return "alias,all,alter,analyzer,and,any,array,as,asc," +
-          "always,array,add," +
-          "bernoulli,between,blob,boolean,by,byte,begin," +
-          "case,cast,catalogs,char_filters,clustered,coalesce,columns," +
-          "constraint,copy,create,cross,current,current_date,current_time," +
-          "current_timestamp,current_schema, column," +
-          "date,day,delete,desc,describe,directory,distinct,distributed," +
-          "double,drop,dynamic,delete,duplicate,default," +
-          "else,end,escape,except,exists,explain,extends,extract," +
-          "false,first,float,following,for,format,from,full,fulltext,functions," +
-          "graphviz,group,geo_point,geo_shape,global,generated," +
-          "having,hour," +
-          "if,ignored,in,index,inner,insert,int,integer,intersect,interval," +
-          "into,ip,is,isolation," +
-          "join," +
-          "last,left,like,limit,logical,long,local,level," +
-          "materialized,minute,month,match," +
-          "natural,not,null,nulls," +
-          "object,off,offset,on,or,order,outer,over,optmize,only," +
-          "partition,partitioned,partitions,plain,preceding,primary_key," +
-          "range,recursive,refresh,reset,right,row,rows,repository,restore," +
-          "schemas,second,select,set,shards,short,show,some,stratify," +
-          "strict,string_type,substring,system,select,snapshot,session," +
-          "table,tables,tablesample,text,then,time,timestamp,to,tokenizer," +
-          "token_filters,true,type,try_cast,transaction,tablesample," +
-          "transient," +
-          "unbounded,union,update,using," +
-          "values,view," +
-          "when,where,with," +
-          "year";
+    return "alias,all,alter,analyzer,and,any,array,as,asc,"
+          + "always,array,add,"
+          + "bernoulli,between,blob,boolean,by,byte,begin,"
+          + "case,cast,catalogs,char_filters,clustered,coalesce,columns,"
+          + "constraint,copy,create,cross,current,current_date,current_time,"
+          + "current_timestamp,current_schema, column,"
+          + "date,day,delete,desc,describe,directory,distinct,distributed,"
+          + "double,drop,dynamic,delete,duplicate,default,"
+          + "else,end,escape,except,exists,explain,extends,extract,"
+          + "false,first,float,following,for,format,from,full,fulltext,functions,"
+          + "graphviz,group,geo_point,geo_shape,global,generated,"
+          + "having,hour,"
+          + "if,ignored,in,index,inner,insert,int,integer,intersect,interval,"
+          + "into,ip,is,isolation,"
+          + "join,"
+          + "last,left,like,limit,logical,long,local,level,"
+          + "materialized,minute,month,match,"
+          + "natural,not,null,nulls,"
+          + "object,off,offset,on,or,order,outer,over,optmize,only,"
+          + "partition,partitioned,partitions,plain,preceding,primary_key,"
+          + "range,recursive,refresh,reset,right,row,rows,repository,restore,"
+          + "schemas,second,select,set,shards,short,show,some,stratify,"
+          + "strict,string_type,substring,system,select,snapshot,session,"
+          + "table,tables,tablesample,text,then,time,timestamp,to,tokenizer,"
+          + "token_filters,true,type,try_cast,transaction,tablesample,"
+          + "transient,"
+          + "unbounded,union,update,using,"
+          + "values,view,"
+          + "when,where,with,"
+          + "year";
   }
 
   public String getNumericFunctions() throws SQLException {
-    return "abs,ceil,floor,ln,log,random,round,sqrt,sin,asin,cos," +
-           "acos,tan,atan";
+    return "abs,ceil,floor,ln,log,random,round,sqrt,sin,asin,cos,"
+           + "acos,tan,atan";
   }
 
   public String getStringFunctions() throws SQLException {
-    return "concat,format,substr,char_length,bit_length,octet_length,"+
-           "lower,upper";
+    return "concat,format,substr,char_length,bit_length,octet_length,"
+           + "lower,upper";
   }
 
   public String getSystemFunctions() throws SQLException {
@@ -984,8 +985,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getTables(String catalog,
                              String schemaPattern,
                              String tableNamePattern,
-                             String types[]) throws SQLException {
-    Field fields[] = new Field[10];
+                             String[] types) throws SQLException {
+    Field[] fields = new Field[10];
     fields[0] = new Field("TABLE_CAT", Oid.VARCHAR);
     fields[1] = new Field("TABLE_SCHEM", Oid.VARCHAR);
     fields[2] = new Field("TABLE_NAME", Oid.VARCHAR);
@@ -1071,7 +1072,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public CrateVersion getCrateVersion() throws SQLException {
     ResultSet rs = connection.createStatement()
-      .executeQuery("select version['number'] as version from sys.nodes limit 1");
+            .executeQuery("select version['number'] as version from sys.nodes limit 1");
     if (rs.next()) {
       return new CrateVersion(rs.getString("version"));
     }
@@ -1224,7 +1225,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public ResultSet getTableTypes() throws SQLException {
-    Field f[] = new Field[1];
+    Field[] f = new Field[1];
     List<byte[][]> v = new ArrayList<>();
     f[0] = new Field("TABLE_TYPE", Oid.VARCHAR);
     v.add(new byte[][] {connection.encodeString("SYSTEM TABLE")});
@@ -1312,7 +1313,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
           tuple[23] = rs.getBytes("is_generated");
         }
       }
-        tuples.add(tuple);
+      tuples.add(tuple);
     }
     return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(fields, tuples);
   }
@@ -1322,15 +1323,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     if (getCrateVersion().before("2.0.0")) {
       select = "SELECT " + schemaName + ", table_name, column_name, data_type, ordinal_position";
     } else {
-      select = "SELECT " + schemaName + ", table_name, column_name, data_type, ordinal_position, table_catalog," +
-              " numeric_precision, numeric_precision_radix, column_default, character_octet_length, is_nullable," +
-              "is_generated";
+      select = "SELECT " + schemaName + ", table_name, column_name, data_type, ordinal_position, table_catalog,"
+              + " numeric_precision, numeric_precision_radix, column_default, character_octet_length, is_nullable,"
+              + "is_generated";
     }
-    return select +
-            " FROM information_schema.columns " +
-            infoSchemaTableWhereClause +
-            " AND column_name NOT LIKE '%[%]' AND column_name NOT LIKE '%.%'" +
-            " ORDER BY " + schemaName + ", table_name, ordinal_position";
+    return select
+            + " FROM information_schema.columns "
+            + infoSchemaTableWhereClause
+            + " AND column_name NOT LIKE '%[%]' AND column_name NOT LIKE '%.%'"
+            + " ORDER BY " + schemaName + ", table_name, ordinal_position";
   }
 
   private int sqlTypeOfCrateType(String dataType) {
@@ -1602,15 +1603,15 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       fields[5] = new Field("PK_NAME", Oid.VARCHAR);
 
       String schemaName = getCrateSchemaName();
-      StringBuilder sql = new StringBuilder("SELECT NULL AS TABLE_CAT, " +
-                                            "  " + schemaName + " AS TABLE_SCHEM, " +
-                                            "  table_name as TABLE_NAME, " +
-                                            "  constraint_name AS COLUMN_NAMES, " +
-                                            "  0 AS KEY_SEQ, " +
-                                            "  NULL AS PK_NAME " +
-                                            "FROM information_schema.table_constraints " +
-                                            "WHERE '_id' != ANY(constraint_name) " +
-                                            "  AND table_name = '" + connection.escapeString(table) + "' ");
+      StringBuilder sql = new StringBuilder("SELECT NULL AS TABLE_CAT, "
+                                            + "  " + schemaName + " AS TABLE_SCHEM, "
+                                            + "  table_name as TABLE_NAME, "
+                                            + "  constraint_name AS COLUMN_NAMES, "
+                                            + "  0 AS KEY_SEQ, "
+                                            + "  NULL AS PK_NAME "
+                                            + "FROM information_schema.table_constraints "
+                                            + "WHERE '_id' != ANY(constraint_name) "
+                                            + "  AND table_name = '" + connection.escapeString(table) + "' ");
       if (schema != null) {
         sql.append("  AND " + schemaName + "= '" + connection.escapeString(schema) + "' ");
       }
@@ -1653,14 +1654,14 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
       } else {
         catalogField = "kcu.table_catalog";
       }
-      StringBuilder sql = new StringBuilder("SELECT " + catalogField + " AS \"TABLE_CAT\",\n" +
-              "  kcu." + schemaField + " AS \"TABLE_SCHEM\",\n" +
-              "  kcu.table_name AS \"TABLE_NAME\",\n" +
-              "  kcu.column_name AS \"COLUMN_NAME\",\n" +
-              "  kcu.ordinal_position AS \"KEY_SEQ\",\n" +
-              "  kcu.constraint_name AS \"PK_NAME\"\n" +
-              " FROM information_schema.key_column_usage kcu\n" +
-              " WHERE kcu.table_name = '" + connection.escapeString(table) + "'\n");
+      StringBuilder sql = new StringBuilder("SELECT " + catalogField + " AS \"TABLE_CAT\",\n"
+              + "  kcu." + schemaField + " AS \"TABLE_SCHEM\",\n"
+              + "  kcu.table_name AS \"TABLE_NAME\",\n"
+              + "  kcu.column_name AS \"COLUMN_NAME\",\n"
+              + "  kcu.ordinal_position AS \"KEY_SEQ\",\n"
+              + "  kcu.constraint_name AS \"PK_NAME\"\n"
+              + " FROM information_schema.key_column_usage kcu\n"
+              + " WHERE kcu.table_name = '" + connection.escapeString(table) + "'\n");
       if (schema != null) {
         sql.append("  AND kcu." + schemaField + " = '" + connection.escapeString(schema) + "'\n");
       }
@@ -1822,17 +1823,17 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
 
   public ResultSet getTypeInfo() throws SQLException {
 
-    Field f[] = new Field[18];
+    Field[] f = new Field[18];
     List<byte[][]> v = new ArrayList<>(); // The new ResultSet tuple stuff
 
-    byte bNullable[] = connection.encodeString(Integer.toString(typeNullable));
-    byte bSearchable[] = connection.encodeString(Integer.toString(typeSearchable));
-    byte bPredBasic[] = connection.encodeString(Integer.toString(typePredBasic));
-    byte bPredNone[] = connection.encodeString(Integer.toString(typePredNone));
-    byte bTrue[] = connection.encodeString("t");
-    byte bFalse[] = connection.encodeString("f");
-    byte bZero[] = connection.encodeString("0");
-    byte b10[] = connection.encodeString("10");
+    byte[] bNullable = connection.encodeString(Integer.toString(typeNullable));
+    byte[] bSearchable = connection.encodeString(Integer.toString(typeSearchable));
+    byte[] bPredBasic = connection.encodeString(Integer.toString(typePredBasic));
+    byte[] bPredNone = connection.encodeString(Integer.toString(typePredNone));
+    byte[] bTrue = connection.encodeString("t");
+    byte[] bFalse = connection.encodeString("f");
+    byte[] bZero = connection.encodeString("0");
+    byte[] b10 = connection.encodeString("10");
 
     f[0] = col("TYPE_NAME");
     f[1] = col("DATA_TYPE", Oid.INT2);
@@ -2075,8 +2076,8 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     v.add(row.clone());
 
     String[] arrayTypes = new String[]{"string_array", "ip_array", "long_array",
-            "integer_array", "short_array", "boolean_array", "byte_array",
-            "float_array", "double_array", "object_array"};
+        "integer_array", "short_array", "boolean_array", "byte_array",
+        "float_array", "double_array", "object_array"};
     for (int i = 11; i < 11 + arrayTypes.length; i++) {
       row[0] = connection.encodeString(arrayTypes[i - 11]);
       row[1] = connection.encodeString(Integer.toString(Types.ARRAY));
@@ -2263,7 +2264,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
             col("SPECIFIC_NAME"));
   }
 
-    public ResultSet getFunctionColumns(String catalog, String schemaPattern,
+  public ResultSet getFunctionColumns(String catalog, String schemaPattern,
                                         String functionNamePattern, String columnNamePattern)
             throws SQLException {
     return emptyResult(
@@ -2430,7 +2431,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     return new Field(name, Oid.VARCHAR);
   }
 
-  private final ResultSet emptyResult(Field... fields) throws SQLException {
+  private ResultSet emptyResult(Field... fields) throws SQLException {
     return ((BaseStatement) createMetaDataStatement()).createDriverResultSet(fields, Collections.<byte[][]>emptyList());
   }
 }

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgPreparedStatement.java
@@ -5,8 +5,6 @@
 
 package org.postgresql.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.Driver;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.CachedQuery;
@@ -28,6 +26,9 @@ import org.postgresql.util.PGobject;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 import org.postgresql.util.ReaderInputStream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java
@@ -5,7 +5,6 @@
 
 package org.postgresql.jdbc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.postgresql.PGResultSetMetaData;
 import org.postgresql.PGStatement;
 import org.postgresql.core.BaseConnection;
@@ -26,6 +25,8 @@ import org.postgresql.util.PGobject;
 import org.postgresql.util.PGtokenizer;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
@@ -2952,8 +2953,8 @@ public class PgResultSet implements ResultSet, org.postgresql.PGRefCursorResultS
 
   public static Byte toByte(String s) throws SQLException {
     if (s != null) {
-        s = s.trim();
-        return Byte.parseByte(s);
+      s = s.trim();
+      return Byte.parseByte(s);
     }
     return 0; // SQL NULL
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/PoolingDataSourceTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/PoolingDataSourceTest.java
@@ -5,19 +5,20 @@
 
 package org.postgresql.test.jdbc2.optional;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.postgresql.ds.common.BaseDataSource;
 import org.postgresql.jdbc2.optional.PoolingDataSource;
+
+import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Minimal tests for pooling DataSource. Needs many more.
@@ -146,7 +147,7 @@ public class PoolingDataSourceTest extends BaseDataSourceTest {
 
   @Test
   public void testLoadBalanceHostsIsEnabledByDefault() {
-      initializeDataSource();
-      assertTrue(bds.getLoadBalanceHosts());
+    initializeDataSource();
+    assertTrue(bds.getLoadBalanceHosts());
   }
 }


### PR DESCRIPTION
I haven't been able to make the tests work, see GH-48. At least, this patch makes `mvn checkstyle:check` succeed, in order to be more confident about any changes which may happen with GH-61.