### PR TITLE
Maintenance: Add minimal CI configuration for GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test
+on:
+
+  pull_request:
+  push:
+    branches: [ "REL42.2.5_crate" ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: "Java ${{ matrix.java-version }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest" ]
+        java-version: [
+          # LTS
+          "8", "11", "17",
+          # Current
+          "20",
+        ]
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "${{ matrix.java-version }}"
+          cache: "maven"
+
+      - name: Run linter and software tests
+        run: |
+          
+          # Run linter
+          mvn checkstyle:check
+
+          # TODO: Run software tests.
+          # https://github.com/crate/pgjdbc/issues/48
+          # mvn package


### PR DESCRIPTION
Let's gradually bring in some automated validation for this project. Currrently, it only runs `mvn checkstyle:check`, because the tests are apparently broken, see GH-48. However, this protection will at least give us more confidence for bringing in GH-61.