### PR TITLE
Maintenance: Run software tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,5 @@ jobs:
           # Run linter
           mvn checkstyle:check
 
-          # TODO: Run software tests.
-          # https://github.com/crate/pgjdbc/issues/48
-          # mvn package
+          # Run software tests.
+          mvn package


### PR DESCRIPTION
This patch accompanies GH-48, in order to demonstrate that the tests are broken, and to eventually fix them.